### PR TITLE
Update Trimp damage calculations for v4.8

### DIFF
--- a/AutoTrimps2.js
+++ b/AutoTrimps2.js
@@ -52,7 +52,7 @@ function initializeAutoTrimps() {
     ATscriptLoad('','SettingsGUI');   //populate Settings GUI
     ATscriptLoad('','Graphs');        //populate Graphs
     //Load modules:
-    ATmoduleList = ['query', 'portal', 'upgrades', 'heirlooms', 'buildings', 'jobs', 'equipment', 'gather', 'stance', 'battlecalc', 'maps', 'breedtimer', 'dynprestige', 'fight', 'scryer', 'magmite', 'other', 'import-export', 'perks', 'fight-info', 'performance', 'ATcalc'];
+    ATmoduleList = ['query', 'portal', 'upgrades', 'heirlooms', 'buildings', 'jobs', 'equipment', 'gather', 'stance', 'battlecalc', 'maps', 'breedtimer', 'dynprestige', 'fight', 'scryer', 'magmite', 'other', 'import-export', 'perks', 'fight-info', 'performance'];
     for (var m in ATmoduleList) {
         ATscriptLoad(modulepath, ATmoduleList[m]);
     }
@@ -237,8 +237,8 @@ function mainLoop() {
     else if (getPageSetting('AutoStance')==2) autoStance2();    //"Auto Stance #2"         (")
     else if (getPageSetting('AutoStance')==3) autoStance3();    //"Auto Stance #3"         (")
     if (getPageSetting('UseAutoGen')) autoGenerator();          //"Auto Generator ON" (magmite.js)
-    if (getPageSetting('BetterAutoFight')==1) betterAutoFight();        //"Better Auto Fight" 
-    if (getPageSetting('BetterAutoFight')==2) betterAutoFight2();     //"Better Auto Fight2" 
+    if (getPageSetting('BetterAutoFight')==1) betterAutoFight();        //"Better Auto Fight"
+    if (getPageSetting('BetterAutoFight')==2) betterAutoFight2();     //"Better Auto Fight2"
     if (getPageSetting('BetterAutoFight')==3) betterAutoFight3();     //"Better Auto Fight3"
     var forcePrecZ = (getPageSetting('ForcePresZ')<0) || (game.global.world<getPageSetting('ForcePresZ'));
     if (getPageSetting('DynamicPrestige2')>0 && forcePrecZ) prestigeChanging2(); //"Dynamic Prestige" (dynprestige.js)

--- a/modules/ATcalc.js
+++ b/modules/ATcalc.js
@@ -1,5 +1,0 @@
-function calculateDamageAT() {
-var trimpATK1 = calculateDamage(game.global.soldierCurrentAttack, true, true);
-var trimpATK = parseFloat(trimpATK1)
-return trimpATK;
-}

--- a/modules/battlecalc.js
+++ b/modules/battlecalc.js
@@ -240,113 +240,165 @@ function getBattleStats(what,form,crit) {
     return currentCalc;
 }
 
-function calcOurDmg(number,maxormin,disableStances,disableFlucts) { //number = base attack
-    var fluctuation = .2; //%fluctuation
-    var maxFluct = -1;
-    var minFluct = -1;
-    //Situational Trimp damage increases
-    if (game.global.radioStacks > 0) {
-        number *= (1 - (game.global.radioStacks * 0.1));
-    }
-    if (game.global.antiStacks > 0) {
-        number *= ((game.global.antiStacks * game.portal.Anticipation.level * game.portal.Anticipation.modifier) + 1);
-        updateAntiStacks();
-    }
-  
-    if (game.global.achievementBonus > 0){
-        number *= (1 + (game.global.achievementBonus / 100));
-    }
-    if (game.global.challengeActive == "Discipline"){
-        fluctuation = .995;
-    }
-    else if (game.portal.Range.level > 0){
-        minFluct = fluctuation - (.02 * game.portal.Range.level);
-    }
-    if (game.global.challengeActive == "Decay"){
-        number *= 5;
-        number *= Math.pow(0.995, game.challenges.Decay.stacks);
-    }
-    if (game.global.roboTrimpLevel > 0){
-        number *= ((0.2 * game.global.roboTrimpLevel) + 1);
-    }
-    if (game.global.challengeActive == "Lead" && ((game.global.world % 2) == 1)){
-        number *= 1.5;
-    }
-    if (game.goldenUpgrades.Battle.currentBonus > 0){
-        number *= game.goldenUpgrades.Battle.currentBonus + 1;
-    }
-    if (game.talents.voidPower.purchased && game.global.voidBuff){
-        var vpAmt = (game.talents.voidPower2.purchased) ? ((game.talents.voidPower3.purchased) ? 65 : 35) : 15;
-        number *= ((vpAmt / 100) + 1);
-    }
-    if (game.global.totalSquaredReward > 0){
-        number *= ((game.global.totalSquaredReward / 100) + 1);
-    }
-    if (game.talents.magmamancer.purchased){
-        number *= game.jobs.Magmamancer.getBonusPercent();
-    }
-    if (game.talents.stillRowing2.purchased){
-        number *= ((game.global.spireRows * 0.06) + 1);
-    }
-    if (game.talents.healthStrength.purchased && mutations.Healthy.active()){
-        number *= ((0.15 * mutations.Healthy.cellCount()) + 1);
-    }
-    if (Fluffy.isActive()){
-        number *= Fluffy.getDamageModifier();
-    }
-    if (game.jobs.Amalgamator.owned > 0){
-        number *= game.jobs.Amalgamator.getDamageMult();
-    }
-    if (game.jobs.Amalgamator.owned > 0){
-        number *= game.jobs.Amalgamator.getHealthMult();
-    }
-    if (game.singleRunBonuses.sharpTrimps.owned) {
+function calcOurDmg(minMaxAvg, incStance, incFlucts) {
+  // This function is adapted from calculateDamage() function in main.js of Trimps (trimps.github.io)
+  // https://github.com/Trimps/Trimps.github.io
+  // Trimps is Copyright (C) Zach Hood (2016)
+
+  // Calculates the minimum, maximum or average Trimp attack while accounting
+  // for daily modifiers, crits, megacrits etc.
+  // minMaxAvg is one of "min", "max", or "avg" depending on what is wnated
+  // incStance is true if formation damage modifiers are to be included,
+  // false otherwise
+
+  var number = game.global.soldierCurrentAttack;
+  var fluctuation = .2; //%fluctuation
+	var maxFluct = -1;
+	var minFluct = -1;
+
+	//Situational Trimp damage increases
+	if (game.jobs.Amalgamator.owned > 0){
+		number *= game.jobs.Amalgamator.getDamageMult();
+	}
+	if (game.challenges.Electricity.stacks > 0) { //Electricity
+		number *= (1 - (game.challenges.Electricity.stacks * 0.1));
+	}
+	if (game.global.antiStacks > 0) {
+		number *= ((game.global.antiStacks * game.portal.Anticipation.level * game.portal.Anticipation.modifier) + 1);
+    //			updateAntiStacks();
+	}
+	if (!game.global.mapsActive && game.global.mapBonus > 0){
+		number *= ((game.global.mapBonus * .2) + 1);
+	}
+	if (game.global.titimpLeft >= 1 && game.global.mapsActive){
+		number *= 2;
+	}
+	if (game.global.achievementBonus > 0){
+		number *= (1 + (game.global.achievementBonus / 100));
+	}
+	if (game.global.challengeActive == "Discipline"){
+		fluctuation = .995;
+	}
+	else if (game.portal.Range.level > 0){
+		minFluct = fluctuation - (.02 * game.portal.Range.level);
+	}
+	if (game.global.challengeActive == "Decay"){
+		number *= 5;
+		number *= Math.pow(0.995, game.challenges.Decay.stacks);
+	}
+	if (game.global.roboTrimpLevel > 0){
+		number *= ((0.2 * game.global.roboTrimpLevel) + 1);
+	}
+	if (game.global.challengeActive == "Lead" && ((game.global.world % 2) == 1)){
 		number *= 1.5;
-    }
-    number *= (1 + (1 - game.empowerments.Ice.getCombatModifier()));
+	}
+	if (game.goldenUpgrades.Battle.currentBonus > 0){
+		number *= game.goldenUpgrades.Battle.currentBonus + 1;
+	}
+	if (game.talents.voidPower.purchased && game.global.voidBuff){
+		var vpAmt = (game.talents.voidPower2.purchased) ? ((game.talents.voidPower3.purchased) ? 65 : 35) : 15;
+		number *= ((vpAmt / 100) + 1);
+	}
+	if (game.global.totalSquaredReward > 0){
+		number *= ((game.global.totalSquaredReward / 100) + 1)
+	}
+	if (getEmpowerment() == "Ice"){
+		number *= 1 + (1 - game.empowerments.Ice.getCombatModifier());
+	}
+	if (game.talents.magmamancer.purchased){
+		number *= game.jobs.Magmamancer.getBonusPercent();
+	}
+	if (game.talents.stillRowing2.purchased){
+		number *= ((game.global.spireRows * 0.06) + 1);
+	}
+	if (game.talents.healthStrength.purchased && mutations.Healthy.active()){
+		number *= ((0.15 * mutations.Healthy.cellCount()) + 1);
+	}
+	if (game.global.sugarRush > 0){
+		number *= sugarRush.getAttackStrength();
+	}
+	if (game.global.challengeActive == "Life") {
+		number *= game.challenges.Life.getHealthMult();
+	}
+	if (game.singleRunBonuses.sharpTrimps.owned){
+		number *= 1.5;
+	}
+	if (game.global.challengeActive == "Daily"){
+		if (typeof game.global.dailyChallenge.minDamage !== 'undefined'){
+			if (minFluct == -1) minFluct = fluctuation;
+			minFluct += dailyModifiers.minDamage.getMult(game.global.dailyChallenge.minDamage.strength);
+		}
+		if (typeof game.global.dailyChallenge.maxDamage !== 'undefined'){
+			if (maxFluct == -1) maxFluct = fluctuation;
+			maxFluct += dailyModifiers.maxDamage.getMult(game.global.dailyChallenge.maxDamage.strength);
+		}
+		if (typeof game.global.dailyChallenge.weakness !== 'undefined'){
+			number *= dailyModifiers.weakness.getMult(game.global.dailyChallenge.weakness.strength, game.global.dailyChallenge.weakness.stacks);
+		}
+		if (typeof game.global.dailyChallenge.oddTrimpNerf !== 'undefined' && ((game.global.world % 2) == 1)){
+				number *= dailyModifiers.oddTrimpNerf.getMult(game.global.dailyChallenge.oddTrimpNerf.strength);
+		}
+		if (typeof game.global.dailyChallenge.evenTrimpBuff !== 'undefined' && ((game.global.world % 2) == 0)){
+				number *= dailyModifiers.evenTrimpBuff.getMult(game.global.dailyChallenge.evenTrimpBuff.strength);
+		}
+		if (typeof game.global.dailyChallenge.rampage !== 'undefined'){
+			number *= dailyModifiers.rampage.getMult(game.global.dailyChallenge.rampage.strength, game.global.dailyChallenge.rampage.stacks);
+		}
+	}
+	if (Fluffy.isActive()){
+		number *= Fluffy.getDamageModifier();
+	}
 
-    if (game.global.challengeActive == "Daily"){
-        if (typeof game.global.dailyChallenge.minDamage !== 'undefined'){
-            if (minFluct == -1) minFluct = fluctuation;
-            minFluct += dailyModifiers.minDamage.getMult(game.global.dailyChallenge.minDamage.strength);
-        }
-        if (typeof game.global.dailyChallenge.maxDamage !== 'undefined'){
-            if (maxFluct == -1) maxFluct = fluctuation;
-            maxFluct += dailyModifiers.maxDamage.getMult(game.global.dailyChallenge.maxDamage.strength);
-        }
-        if (typeof game.global.dailyChallenge.weakness !== 'undefined'){
-            number *= dailyModifiers.weakness.getMult(game.global.dailyChallenge.weakness.strength, game.global.dailyChallenge.weakness.stacks);
-        }
-        if (typeof game.global.dailyChallenge.oddTrimpNerf !== 'undefined' && ((game.global.world % 2) == 1)){
-                number *= dailyModifiers.oddTrimpNerf.getMult(game.global.dailyChallenge.oddTrimpNerf.strength);
-        }
-        if (typeof game.global.dailyChallenge.evenTrimpBuff !== 'undefined' && ((game.global.world % 2) == 0)){
-                number *= dailyModifiers.evenTrimpBuff.getMult(game.global.dailyChallenge.evenTrimpBuff.strength);
-        }
-        if (typeof game.global.dailyChallenge.rampage !== 'undefined'){
-            number *= dailyModifiers.rampage.getMult(game.global.dailyChallenge.rampage.strength, game.global.dailyChallenge.rampage.stacks);
-        }
-    }
-    if (!disableStances) {
-        //Formations
-        if (game.global.formation == 2)
-            number /= 4;
-        else if (game.global.formation != "0")
-            number *= 2;
-    }
-    if (!disableFlucts) {
-        if (minFluct > 1) minFluct = 1;
-        if (maxFluct == -1) maxFluct = fluctuation;
-        if (minFluct == -1) minFluct = fluctuation;
-        var min = Math.floor(number * (1 - minFluct));
-        var max = Math.ceil(number + (number * maxFluct));
+  // reverse effects of stance if incStance is false;
+  if (!incStance && game.global.formation !== 0) {
+    number /= (game.global.formation == 2) ? 4 : 0.5;
+  }
 
-        //number = Math.floor(Math.random() * ((max + 1) - min)) + min;
-        return maxormin ? max : min;
+  // Calculate effect of crits and megacrits on max, min, and avg damage
+	var min = number;
+  var max = number;
+  var avg = number;
+
+  var critTier = 0;
+  var critChance = getPlayerCritChance();
+  if (critChance > 0){
+    critTier = Math.floor(critChance);
+    critChance = critChance % 1;
+
+    if (critTier > 0){
+      min *= getPlayerCritDamageMult();
+      max = min;
+      if (critTier > 1){
+        min *= getMegaCritDamageMult(critTier);
+        if (critChance > 0) max = number * getMegaCritDamageMult(critTier + 1);
+        else max = min;
+      }
+      avg = max * critChance + min * (1 - critChance);
     }
-    else
-        return number;
+  }
+  if critChance < 0 {
+    min *= 0.2;
+    if (critChance <= -1) max *= 0.2;
+    avg = max * (1 + critChance) + min * -critChance;
+  }
+
+  if (incFlucts) {
+    // Account for variation in attack as modified by Range perk;
+    if (minFluct > 1) minFluct = 1;
+    if (maxFluct == -1) maxFluct = fluctuation;
+    if (minFluct == -1) minFluct = fluctuation;
+
+    min *= (1 - minFluct);
+    max *= (1 + maxFluct);
+    avg *= 1 + (maxFluct - minFluct)/2;
+  }
+
+  if (minMaxAvg == "min") return min;
+  else if (minMaxAvg == "max") return max;
+  else if (minMaxAvg == "avg") return avg;
+
 }
+
 
 
 function calcBadGuyDmg(enemy,attack,daily,maxormin,disableFlucts) {

--- a/modules/maps.js
+++ b/modules/maps.js
@@ -133,23 +133,21 @@ function autoMap() {
 
     //START CALCULATING DAMAGES:
     var AutoStance = getPageSetting('AutoStance');
-    //calculate crits (baseDamage was calced in function autoStance)    this is a weighted average of nonCrit + Crit. (somewhere in the middle)
-    if (getPlayerCritChance() > 1) {
-    ourBaseDamage = (baseDamage * (1 - getPlayerCritChance()) + (baseDamage * getPlayerCritChance() * getPlayerCritDamageMult() * additionalCritMulti));
-    }
-    else if (getPlayerCritChance() > 0) {
-    ourBaseDamage = (baseDamage * (1 - getPlayerCritChance()) + (baseDamage * getPlayerCritChance() * getPlayerCritDamageMult()));
-    }
-    else if (getPlayerCritChance() <= 0) {
-    ourBaseDamage = baseDamage;
-    }
-    
+    // crits and megacrits already accounted for now
+    // For farming, we always want average damage
+    ourBaseDamage = calcOurDmg("avg",false,true);
+
     //calculate with map bonus
     var mapbonusmulti = 1 + (0.20 * game.global.mapBonus);
-    //(autostance2 has mapbonusmulti built in)
-    ourBaseDamage2 = ourBaseDamage; //keep a version without mapbonus
-    ourBaseDamage *= mapbonusmulti;
-
+    //(autostances have mapbonusmulti built in)
+    if (game.global.mapsActive  || game.global.preMapsActive) {
+      ourBaseDamage2 = ourBaseDamage; //keep a version without mapbonus
+      ourBaseDamage *= mapbonusmulti;
+    }
+    else {
+      ourBaseDamage2 = ourBaseDamage;
+      ourBaseDamage2 /= mapbonusmulti;
+    }
     //get average enemyhealth and damage for the next zone, cell 50, snimp type and multiply it by a max range fluctuation of 1.2
     var enemyDamage;
     var enemyHealth;
@@ -214,6 +212,7 @@ function autoMap() {
     var pierceMod = (game.global.brokenPlanet && !game.global.mapsActive) ? getPierceAmt() : 0;
     const FORMATION_MOD_1 = game.upgrades.Dominance.done ? 2 : 1;
     //asks if we can survive x number of hits in either D stance or X stance.
+    // health calculation looks off as damage in excess of block not accounted for in else clause of ternary operator
     enoughHealth = (baseHealth / FORMATION_MOD_1 > customVars.numHitsSurvived * (enemyDamage - baseBlock / FORMATION_MOD_1 > 0 ? enemyDamage - baseBlock / FORMATION_MOD_1 : enemyDamage * pierceMod));
     enoughDamage = (ourBaseDamage * customVars.enoughDamageCutoff > enemyHealth);
 

--- a/modules/scryer.js
+++ b/modules/scryer.js
@@ -92,9 +92,10 @@ function useScryerStance() {
       useoverkill = false;
     //Overkill button being on and being able to overkill in S will override any setting other than never spire & nature zone, regardless.
     if (useoverkill && game.portal.Overkill.level > 0) {
-        var avgDamage = (baseDamage * (1-getPlayerCritChance()) + (baseDamage * getPlayerCritChance() * getPlayerCritDamageMult()));
+        // being conservative about overkill choice for maximum speed - using min
+        var minDamage = calcOurDmg("min",false,true);
         var Sstance = 0.5;
-        var ovkldmg = avgDamage * Sstance * (game.portal.Overkill.level*0.005);
+        var ovkldmg = minDamage * Sstance * (game.portal.Overkill.level*0.005);
         //are we going to overkill in S?
         var ovklHDratio = getCurrentEnemy(1).maxHealth / ovkldmg;
         if (ovklHDratio < 8) {

--- a/modules/stance.js
+++ b/modules/stance.js
@@ -1,8 +1,10 @@
 //MODULES["stance"] = {};
 
 function calcBaseDamageinX() {
-    //baseDamage
-    baseDamage = (getBattleStats("attack", false, true));
+    // baseDamage
+    // baseDamage = (getBattleStats("attack", false, true));
+    // calculate average damage including crit and megacrit effects, excluding stance and including flucts
+    baseDamage = calcOurDmg("avg", false, true);
     //baseBlock
     baseBlock = game.global.soldierCurrentBlock;
     //baseHealth
@@ -14,8 +16,9 @@ function calcBaseDamageinX() {
 
 //goes to battlecalc.js which came from Trimps "updates.js" line 1103
 function calcBaseDamageinX2() {
-    //baseDamage - changed getBattleStats() call to exclude crit damage to avoid double counting in maps.js, scryer.js and stance.js
-    baseDamage = getBattleStats("attack", false, false);
+    // baseDamage - now using average damage (excluding stance modifiers, including flucts) including crits and megacrits
+    // "avg" might be better here...
+    baseDamage = calcOurDmg("min", false, true);
     //baseBlock
     baseBlock = getBattleStats("block");
     //baseHealth
@@ -330,8 +333,9 @@ function autoStance2() {
         xDamage += added;
         bDamage += added;
     }
-    baseDamage *= (game.global.titimpLeft > 0 ? 2 : 1); //consider titimp
-    baseDamage *= (!game.global.mapsActive && game.global.mapBonus > 0) ? ((game.global.mapBonus * .2) + 1) : 1;    //consider mapbonus
+    // Handled by calcOurDmg() now
+    // baseDamage *= (game.global.titimpLeft > 0 ? 2 : 1); //consider titimp
+    // baseDamage *= (!game.global.mapsActive && game.global.mapBonus > 0) ? ((game.global.mapBonus * .2) + 1) : 1;    //consider mapbonus
 
     //handle Daily Challenge explosion/suicide
     var xExplosionOK = true;
@@ -340,10 +344,11 @@ function autoStance2() {
         var explosionDmg = 0;
         var explosiveDamage = 1 + game.global.dailyChallenge['explosive'].strength;
 
-        var playerCritMult = getPlayerCritChance() ? getPlayerCritDamageMult() : 1;
-        var playerDCritDmg = (baseDamage*4) * playerCritMult;
-        var playerXCritDmg = (baseDamage) * playerCritMult;
-
+        // var playerCritMult = getPlayerCritChance() ? getPlayerCritDamageMult() : 1;
+        // var playerDCritDmg = (baseDamage*4) * playerCritMult;
+        // var playerXCritDmg = (baseDamage) * playerCritMult;
+        var playerDCritDmg = calcOurDmg("max",false,true) * 4;
+        var playerXCritDmg = calcOurDmg("max",false,true);
         // I don't know if I have to use x or d damage or just the base damage multiplier for this calculation.
         explosionDmg = calcBadGuyDmg(enemy,null,true,true) * explosiveDamage;
         xExplosionOK = ((xHealth - missingHealth > explosionDmg) || (enemyHealth > playerXCritDmg));
@@ -408,15 +413,16 @@ function autoStance2() {
                 setFormation(1);    //the last thing that runs
         }
     }
-    baseDamage /= (game.global.titimpLeft > 0 ? 2 : 1); //unconsider titimp
-    baseDamage /= (!game.global.mapsActive && game.global.mapBonus > 0) ? ((game.global.mapBonus * .2) + 1) : 1;    //unconsider mapbonus
+    // Handled by calcOurDmg() now;
+    // baseDamage /= (game.global.titimpLeft > 0 ? 2 : 1); //unconsider titimp
+    // baseDamage /= (!game.global.mapsActive && game.global.mapBonus > 0) ? ((game.global.mapBonus * .2) + 1) : 1;    //unconsider mapbonus
     return true;
 }
 
 function autoStanceCheck(enemyCrit) {
     if (game.global.gridArray.length === 0) return [true,true];
     //baseDamage              //in stance attack,              //min, //disable stances, //enable flucts
-    var ourDamage = calcOurDmg(game.global.soldierCurrentAttack,true,true,true);
+    var ourDamage = calcOurDmg("min",false,true);
     //baseBlock
     var ourBlock = game.global.soldierCurrentBlock;
     //baseHealth


### PR DESCRIPTION
* rewrite calcOurDmg() function in battlecalc.js to accout for changes in Trimps 4.8

function calcOurDmg(minMaxAvg, incStance, incFlucts)

minMaxAvg: string; "min", "max", or "avg" as required
incStance: boolean; true to include stance modifiers, false otherwise
incFlucts: boolean; true to account for variation in attack strength as modified by Range perk.

Adapted from Trimps code, calculates minimum, maximum, and average damage while correctly accounting for crit chances > 100%, megacrits, etc and new daily modifiers.

* began updating code to use calcOurDmg in place of other functions and removed local calculations of crit damage etc. where calcOurDmg() has handled it already.

* Deleted modules/ATcalc.js
Nothing uses it, and it's out of date for 4.8