### PR TITLE
Exclude Ice atk bonus from automap calc

### DIFF
--- a/modules/maps.js
+++ b/modules/maps.js
@@ -136,6 +136,11 @@ function autoMap() {
     // crits and megacrits already accounted for now
     // For farming, we always want average damage
     ourBaseDamage = calcOurDmg("avg",false,true);
+    // exclude ice damage in maps to stop jumping in and out of maps, losing titimp bonus
+    // should maybe consider disabling in world too?
+    if (game.global.mapsActive && getEmpowerment() == "Ice"){
+      ourBaseDamage /= 1 + (1 - game.empowerments.Ice.getCombatModifier());
+    }
 
     //calculate with map bonus
     var mapbonusmulti = 1 + (0.20 * game.global.mapBonus);


### PR DESCRIPTION
Excludes Ice attack bonus from automaps attack for mapbonus calculation to stop it jumping in and out of maps, losing any titimp bonus each time.